### PR TITLE
Make Drivetrain use DifferentialDrive

### DIFF
--- a/src/main/java/com/spartronics4915/atlas/commands/QuickTurnDrivetrain.java
+++ b/src/main/java/com/spartronics4915/atlas/commands/QuickTurnDrivetrain.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.PIDOutput;
 import edu.wpi.first.wpilibj.PIDSource;
 import edu.wpi.first.wpilibj.PIDSourceType;
 import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
@@ -25,6 +26,7 @@ public class QuickTurnDrivetrain extends Command implements PIDSource, PIDOutput
 
     private Drivetrain mDrivetrain;
     private PIDController mPIDController;
+    private DifferentialDrive mDifferentialDrive;
 
     public QuickTurnDrivetrain()
     {
@@ -33,9 +35,13 @@ public class QuickTurnDrivetrain extends Command implements PIDSource, PIDOutput
 
         mPIDController = new PIDController(kP, kI, kD, kF, this, this);
         mPIDController.setOutputRange(-1, 1);
-        mPIDController.setInputRange(0, 360); // Guranteed by the Rotation2d class
+        mPIDController.setInputRange(0, 360); // Guaranteed by the Rotation2d class
         mPIDController.setAbsoluteTolerance(kAllowedError);
 
+        mDifferentialDrive = mDrivetrain.getNewDifferentialDrive();
+        // We don't want a deadband for this command
+
+        // Rotate current heading by 180 degrees
         mPIDController.setSetpoint(mDrivetrain.getIMUHeading().rotateBy(Rotation2d.fromDegrees(180)).getDegrees());
     }
 
@@ -49,7 +55,7 @@ public class QuickTurnDrivetrain extends Command implements PIDSource, PIDOutput
     @Override
     protected void execute()
     {
-        SmartDashboard.putNumber("IMU Value", mDrivetrain.getIMUHeading().getDegrees());
+        SmartDashboard.putNumber("IMU Heading", mDrivetrain.getIMUHeading().getDegrees());
         SmartDashboard.putNumber("PID Setpoint", mPIDController.getSetpoint());
     }
 
@@ -103,6 +109,6 @@ public class QuickTurnDrivetrain extends Command implements PIDSource, PIDOutput
     @Override
     public void pidWrite(double output)
     {
-        mDrivetrain.driveOpenLoop(output, -output);
+        mDifferentialDrive.arcadeDrive(0, output);
     }
 }

--- a/src/main/java/com/spartronics4915/atlas/commands/TeleopDrivetrain.java
+++ b/src/main/java/com/spartronics4915/atlas/commands/TeleopDrivetrain.java
@@ -5,6 +5,7 @@ import com.spartronics4915.atlas.OI;
 import com.spartronics4915.atlas.subsystems.Drivetrain;
 
 import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 
 /**
  * TeleopDrivetrain runs the drivetrain using a drive stick.
@@ -13,12 +14,17 @@ public class TeleopDrivetrain extends Command
 {
 
     private Drivetrain mDrivetrain;
+    private DifferentialDrive mDifferentialDrive;
 
-    private static final double kDeadZone = 0.1;
+    private static final double kDeadband = 0.1;
 
     public TeleopDrivetrain()
     {
         mDrivetrain = Drivetrain.getInstance();
+       
+        mDifferentialDrive = mDrivetrain.getNewDifferentialDrive();
+        mDifferentialDrive.setDeadband(kDeadband);
+
         requires(mDrivetrain);
     }
 
@@ -31,19 +37,7 @@ public class TeleopDrivetrain extends Command
     @Override
     protected void execute()
     {
-        double left = OI.sDriveStick.getX() - OI.sDriveStick.getY();
-        double right = OI.sDriveStick.getX() + OI.sDriveStick.getY();
-        if (Math.abs(left) < kDeadZone) {
-            left = 0;
-        }
-        if (Math.abs(right) > kDeadZone) {
-            right = 0;
-        }
-
-        mDrivetrain.driveOpenLoop(
-            Math.max(Math.min(left, 1), -1),
-            Math.max(Math.min(right, 1), -1) // Values should be clamped between -1 and 1
-        );
+        mDifferentialDrive.arcadeDrive(OI.sDriveStick.getY(), OI.sDriveStick.getX());
     }
 
     @Override

--- a/src/main/java/com/spartronics4915/atlas/commands/TeleopDrivetrain.java
+++ b/src/main/java/com/spartronics4915/atlas/commands/TeleopDrivetrain.java
@@ -4,9 +4,7 @@ import com.spartronics4915.atlas.Logger;
 import com.spartronics4915.atlas.OI;
 import com.spartronics4915.atlas.subsystems.Drivetrain;
 
-import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.command.Command;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * TeleopDrivetrain runs the drivetrain using a drive stick.
@@ -15,6 +13,8 @@ public class TeleopDrivetrain extends Command
 {
 
     private Drivetrain mDrivetrain;
+
+    private static final double kDeadZone = 0.1;
 
     public TeleopDrivetrain()
     {
@@ -31,9 +31,18 @@ public class TeleopDrivetrain extends Command
     @Override
     protected void execute()
     {
+        double left = OI.sDriveStick.getX() - OI.sDriveStick.getY();
+        double right = OI.sDriveStick.getX() + OI.sDriveStick.getY();
+        if (Math.abs(left) < kDeadZone) {
+            left = 0;
+        }
+        if (Math.abs(right) > kDeadZone) {
+            right = 0;
+        }
+
         mDrivetrain.driveOpenLoop(
-            Math.max(Math.min(OI.sDriveStick.getX() - OI.sDriveStick.getY(), 1), -1),
-            Math.max(Math.min(OI.sDriveStick.getX() + OI.sDriveStick.getY(), 1), -1)
+            Math.max(Math.min(left, 1), -1),
+            Math.max(Math.min(right, 1), -1) // Values should be clamped between -1 and 1
         );
     }
 

--- a/src/main/java/com/spartronics4915/atlas/subsystems/Drivetrain.java
+++ b/src/main/java/com/spartronics4915/atlas/subsystems/Drivetrain.java
@@ -8,6 +8,7 @@ import com.spartronics4915.util.Rotation2d;
 
 import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.Victor;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 
 /**
  * The subsystem that controls the Drivetrain.
@@ -27,7 +28,7 @@ public class Drivetrain extends SpartronicsSubsystem
     public SpeedController mLeftMotor;
     public SpeedController mRightMotor;
 
-    //IMU
+    // IMU
     public PigeonIMU mIMU;
 
     public static Drivetrain getInstance() {
@@ -40,7 +41,6 @@ public class Drivetrain extends SpartronicsSubsystem
 
     private Drivetrain()
     {
-        
         try
         {
             // Initialize motors
@@ -50,8 +50,6 @@ public class Drivetrain extends SpartronicsSubsystem
             //Initialize IMU
             mIMU = new PigeonIMU(RobotMap.kDriveTrainIMUID);
 
-            // This needs to go at the end. We *don't* set
-            // mInitalized here (we only set it on faliure).
             logInitialized(true);
         }
         catch (Exception e)
@@ -83,9 +81,22 @@ public class Drivetrain extends SpartronicsSubsystem
         return Rotation2d.fromDegrees(ypr[0]);
     }
 
-    public void driveOpenLoop(double left, double right)
+    /*
+    Although we could return the same DifferentialDrive here,
+    reuse could cause bugs (especially with inversion or deadbands).
+    This also allows us to have different settings for different
+    commands.
+
+    One could argue that this allows multiple differential drives
+    to fight, but that was already a possibility with other methods,
+    and we defer stopping conflicts like this to WPILib's scheduler
+    (see the Command.requires method).
+    */
+    public DifferentialDrive getNewDifferentialDrive()
     {
-        mLeftMotor.set(left);
-        mRightMotor.set(right);
+        DifferentialDrive diffDrive = new DifferentialDrive(mLeftMotor, mRightMotor);
+        diffDrive.setMaxOutput(1); 
+        
+        return diffDrive;
     }
 }


### PR DESCRIPTION
This way we don't have to worry about writing our code for deadbands, or maximum outputs, or reversal. It also lets us use Cheesy Drive (see `DifferentialDrive.curvatureDrive()`) if we want (we don't do this currently, but I hope to test and see if this is more controllable than `DifferentialDrive.arcadeDrive()`.)